### PR TITLE
Add jsDelivr links

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,11 +49,13 @@ require('social-likes-next/lib/social-likes_flat.css');  // Flat skin
 
 ### Installation from CDN
 
-You can also [use unpkg](https://unpkg.com/social-likes-next/):
+You can also use [jsDelivr](https://www.jsdelivr.com/package/npm/social-likes-next) or [unpkg](https://unpkg.com/social-likes-next/):
 
 1. Add a script to your the bottom of your HTML’s `<body>`:
 
 ```html
+<script src="https://cdn.jsdelivr.net/npm/social-likes-next/dist/social-likes.min.js"></script>
+<!-- or -->
 <script src="https://unpkg.com/social-likes-next/dist/social-likes.min.js"></script>
 ```
 
@@ -68,6 +70,8 @@ Choose one of the CSS files:
 And add it to your HTML’s `<head>`:
 
 ```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/social-likes-next/dist/social-likes_flat.css">
+<!-- or -->
 <link rel="stylesheet" href="https://unpkg.com/social-likes-next/dist/social-likes_flat.css">
 ```
 


### PR DESCRIPTION
I added [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/social-likes-next) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability.